### PR TITLE
Add a key-value store example

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,10 +23,10 @@ message("protobuf_DIR: ${protobuf_DIR}")
 message("gRPC_DIR: ${gRPC_DIR}")
 
 #Configure compiler options
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 14)
 
 if(MSVC)
-  add_compile_options(/W3 /WX)
+  add_compile_options(/W2 /WX)
 else()
   add_compile_options(-Wall -Wextra -pedantic -Werror -static)
 endif()

--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -1,5 +1,5 @@
 find_package(Threads)
-set(SRC_FILES grpc-client health-check greeter_client)
+set(SRC_FILES grpc-client health-check greeter_client keyvalue-client)
 
 foreach(src_file ${SRC_FILES})
   add_executable(${src_file} ${src_file}.cpp)

--- a/client/caching_interceptor.h
+++ b/client/caching_interceptor.h
@@ -1,0 +1,120 @@
+/*
+ *
+ * Copyright 2018 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <map>
+
+#include <grpcpp/support/client_interceptor.h>
+
+#ifdef BAZEL_BUILD
+#include "examples/protos/keyvaluestore.grpc.pb.h"
+#else
+#include "keyvaluestore.grpc.pb.h"
+#endif
+
+// This is a naive implementation of a cache. A new cache is for each call. For
+// each new key request, the key is first searched in the map and if found, the
+// interceptor fills in the return value without making a request to the server.
+// Only if the key is not found in the cache do we make a request.
+class CachingInterceptor : public grpc::experimental::Interceptor {
+  public:
+    CachingInterceptor(grpc::experimental::ClientRpcInfo *) {}
+
+    void Intercept(::grpc::experimental::InterceptorBatchMethods *methods) override {
+        bool hijack = false;
+        if (methods->QueryInterceptionHookPoint(
+                grpc::experimental::InterceptionHookPoints::PRE_SEND_INITIAL_METADATA)) {
+            // Hijack all calls
+            hijack = true;
+            // Create a stream on which this interceptor can make requests
+            stub_   = keyvaluestore::KeyValueStore::NewStub(methods->GetInterceptedChannel());
+            stream_ = stub_->GetValues(&context_);
+        }
+        if (methods->QueryInterceptionHookPoint(grpc::experimental::InterceptionHookPoints::PRE_SEND_MESSAGE)) {
+            // We know that clients perform a Read and a Write in a loop, so we don't
+            // need to maintain a list of the responses.
+            std::string                   requested_key;
+            const keyvaluestore::Request *req_msg =
+                static_cast<const keyvaluestore::Request *>(methods->GetSendMessage());
+            if (req_msg != nullptr) {
+                requested_key = req_msg->key();
+            } else {
+                // The non-serialized form would not be available in certain scenarios,
+                // so add a fallback
+                keyvaluestore::Request req_msg;
+                auto *                 buffer        = methods->GetSerializedSendMessage();
+                auto                   copied_buffer = *buffer;
+                GPR_ASSERT(
+                    grpc::SerializationTraits<keyvaluestore::Request>::Deserialize(&copied_buffer, &req_msg).ok());
+                requested_key = req_msg.key();
+            }
+
+            // Check if the key is present in the map
+            auto search = cached_map_.find(requested_key);
+            if (search != cached_map_.end()) {
+                std::cout << "Key " << requested_key << "found in map";
+                response_ = search->second;
+            } else {
+                std::cout << "Key " << requested_key << "not found in cache";
+                // Key was not found in the cache, so make a request
+                keyvaluestore::Request req;
+                req.set_key(requested_key);
+                stream_->Write(req);
+                keyvaluestore::Response resp;
+                stream_->Read(&resp);
+                response_ = resp.value();
+                // Insert the pair in the cache for future requests
+                cached_map_.insert({requested_key, response_});
+            }
+        }
+        if (methods->QueryInterceptionHookPoint(grpc::experimental::InterceptionHookPoints::PRE_SEND_CLOSE)) {
+            stream_->WritesDone();
+        }
+        if (methods->QueryInterceptionHookPoint(grpc::experimental::InterceptionHookPoints::PRE_RECV_MESSAGE)) {
+            keyvaluestore::Response *resp = static_cast<keyvaluestore::Response *>(methods->GetRecvMessage());
+            resp->set_value(response_);
+        }
+        if (methods->QueryInterceptionHookPoint(grpc::experimental::InterceptionHookPoints::PRE_RECV_STATUS)) {
+            auto *status = methods->GetRecvStatus();
+            *status      = grpc::Status::OK;
+        }
+        // One of Hijack or Proceed always needs to be called to make progress.
+        if (hijack) {
+            // Hijack is called only once when PRE_SEND_INITIAL_METADATA is present in
+            // the hook points
+            methods->Hijack();
+        } else {
+            // Proceed is an indicator that the interceptor is done intercepting the
+            // batch.
+            methods->Proceed();
+        }
+    }
+
+  private:
+    grpc::ClientContext                                                                        context_;
+    std::unique_ptr<keyvaluestore::KeyValueStore::Stub>                                        stub_;
+    std::unique_ptr<grpc::ClientReaderWriter<keyvaluestore::Request, keyvaluestore::Response>> stream_;
+    std::map<std::string, std::string>                                                         cached_map_;
+    std::string                                                                                response_;
+};
+
+class CachingInterceptorFactory : public grpc::experimental::ClientInterceptorFactoryInterface {
+  public:
+    grpc::experimental::Interceptor *CreateClientInterceptor(grpc::experimental::ClientRpcInfo *info) override {
+        return new CachingInterceptor(info);
+    }
+};

--- a/client/keyvalue-client.cpp
+++ b/client/keyvalue-client.cpp
@@ -40,23 +40,20 @@ class KeyValueStoreClient {
   public:
     KeyValueStoreClient(std::shared_ptr<Channel> channel) : stub_(KeyValueStore::NewStub(channel)) {}
 
-    // Requests each key in the vector and displays the key and its corresponding
-    // value as a pair
     void GetValues(const std::vector<std::string> &keys) {
-        // Context for the client. It could be used to convey extra information to
-        // the server and/or tweak certain RPC behaviors.
         ClientContext context;
-        auto          stream = stub_->GetValues(&context);
+
+        auto stream = stub_->GetValues(&context);
+        Request request;
         for (const auto &key : keys) {
-            // Key we are sending to the server.
-            Request request;
+            request.Clear();
             request.set_key(key);
             stream->Write(request);
 
             // Get the value for the sent key
             Response response;
             stream->Read(&response);
-            std::cout << key << " : " << response.value() << "\n";
+            std::cout << key << ": " << response.value() << "\n";
         }
         stream->WritesDone();
         Status status = stream->Finish();
@@ -71,19 +68,19 @@ class KeyValueStoreClient {
 };
 
 int main() {
-    // Instantiate the client. It requires a channel, out of which the actual RPCs
-    // are created. This channel models a connection to an endpoint (in this case,
-    // localhost at port 50051). We indicate that the channel isn't authenticated
-    // (use of InsecureChannelCredentials()).
+    const std::string      ipaddress = "localhost:50051";
+    grpc::ChannelArguments args;
+
     // In this example, we are using a cache which has been added in as an
     // interceptor.
-    grpc::ChannelArguments                                                              args;
     std::vector<std::unique_ptr<grpc::experimental::ClientInterceptorFactoryInterface>> interceptor_creators;
-    interceptor_creators.push_back(std::unique_ptr<CachingInterceptorFactory>(new CachingInterceptorFactory()));
+    interceptor_creators.push_back(std::make_unique<CachingInterceptorFactory>());
+
     auto channel = grpc::experimental::CreateCustomChannelWithInterceptors(
-        "localhost:50051", grpc::InsecureChannelCredentials(), args, std::move(interceptor_creators));
-    KeyValueStoreClient      client(channel);
-    std::vector<std::string> keys = {"key1", "key2", "key3", "key4", "key5", "key1", "key2", "key4"};
+        ipaddress, grpc::InsecureChannelCredentials(), args, std::move(interceptor_creators));
+
+    KeyValueStoreClient            client(channel);
+    const std::vector<std::string> keys = {"key1", "key2", "key3", "key4", "key5", "key1", "key2", "key4"};
     client.GetValues(keys);
 
     return EXIT_SUCCESS;

--- a/client/keyvalue-client.cpp
+++ b/client/keyvalue-client.cpp
@@ -1,0 +1,90 @@
+/*
+ *
+ * Copyright 2018 gRPC authors.
+ * Copyright 2021 Hung Dang
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <cstdlib>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "grpcpp/grpcpp.h"
+
+#include "caching_interceptor.h"
+
+#include "keyvaluestore.grpc.pb.h"
+
+using grpc::Channel;
+using grpc::ClientContext;
+using grpc::Status;
+using keyvaluestore::KeyValueStore;
+using keyvaluestore::Request;
+using keyvaluestore::Response;
+
+class KeyValueStoreClient {
+  public:
+    KeyValueStoreClient(std::shared_ptr<Channel> channel) : stub_(KeyValueStore::NewStub(channel)) {}
+
+    // Requests each key in the vector and displays the key and its corresponding
+    // value as a pair
+    void GetValues(const std::vector<std::string> &keys) {
+        // Context for the client. It could be used to convey extra information to
+        // the server and/or tweak certain RPC behaviors.
+        ClientContext context;
+        auto          stream = stub_->GetValues(&context);
+        for (const auto &key : keys) {
+            // Key we are sending to the server.
+            Request request;
+            request.set_key(key);
+            stream->Write(request);
+
+            // Get the value for the sent key
+            Response response;
+            stream->Read(&response);
+            std::cout << key << " : " << response.value() << "\n";
+        }
+        stream->WritesDone();
+        Status status = stream->Finish();
+        if (!status.ok()) {
+            std::cout << status.error_code() << ": " << status.error_message() << std::endl;
+            std::cout << "RPC failed";
+        }
+    }
+
+  private:
+    std::unique_ptr<KeyValueStore::Stub> stub_;
+};
+
+int main() {
+    // Instantiate the client. It requires a channel, out of which the actual RPCs
+    // are created. This channel models a connection to an endpoint (in this case,
+    // localhost at port 50051). We indicate that the channel isn't authenticated
+    // (use of InsecureChannelCredentials()).
+    // In this example, we are using a cache which has been added in as an
+    // interceptor.
+    grpc::ChannelArguments                                                              args;
+    std::vector<std::unique_ptr<grpc::experimental::ClientInterceptorFactoryInterface>> interceptor_creators;
+    interceptor_creators.push_back(std::unique_ptr<CachingInterceptorFactory>(new CachingInterceptorFactory()));
+    auto channel = grpc::experimental::CreateCustomChannelWithInterceptors(
+        "localhost:50051", grpc::InsecureChannelCredentials(), args, std::move(interceptor_creators));
+    KeyValueStoreClient      client(channel);
+    std::vector<std::string> keys = {"key1", "key2", "key3", "key4", "key5", "key1", "key2", "key4"};
+    client.GetValues(keys);
+
+    return EXIT_SUCCESS;
+}

--- a/proto/CMakeLists.txt
+++ b/proto/CMakeLists.txt
@@ -2,7 +2,7 @@ find_package(protobuf CONFIG REQUIRED NO_DEFAULT_PATH)
 find_package(gRPC CONFIG REQUIRED NO_DEFAULT_PATH)
 find_package(Threads)
 
-set(PROTO_FILES address.proto addressbook.proto healthcheck.proto helloworld.proto)
+set(PROTO_FILES address.proto addressbook.proto healthcheck.proto helloworld.proto keyvaluestore.proto)
 
 # Add Library target with protobuf sources
 add_library(address ${PROTO_FILES})

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -1,5 +1,5 @@
 find_package(Threads)
-set(SRC_FILES grpc-server greeter_server)
+set(SRC_FILES grpc-server greeter_server keyvalue-server)
 
 foreach(src_file ${SRC_FILES})
   add_executable(${src_file} ${src_file}.cpp)

--- a/server/keyvalue-server.cpp
+++ b/server/keyvalue-server.cpp
@@ -1,0 +1,92 @@
+/*
+ *
+ * Copyright 2018 gRPC authors.
+ * Copyright 2021 Hung Dang.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+#include <cstdlib>
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "grpcpp/grpcpp.h"
+
+#include "keyvaluestore.grpc.pb.h"
+
+using grpc::Server;
+using grpc::ServerBuilder;
+using grpc::ServerContext;
+using grpc::ServerReaderWriter;
+using grpc::Status;
+using keyvaluestore::KeyValueStore;
+using keyvaluestore::Request;
+using keyvaluestore::Response;
+
+struct kv_pair {
+    const char *key = nullptr;
+    const char *value = nullptr;
+};
+
+static const kv_pair kvs_map[] = {
+    {"key1", "value1"}, {"key2", "value2"}, {"key3", "value3"}, {"key4", "value4"}, {"key5", "value5"},
+};
+
+const char *get_value_from_map(const char *key) {
+    for (size_t i = 0; i < sizeof(kvs_map) / sizeof(kv_pair); ++i) {
+        if (strcmp(key, kvs_map[i].key) == 0) {
+            return kvs_map[i].value;
+        }
+    }
+    return "";
+}
+
+// Logic and data behind the server's behavior.
+class KeyValueStoreServiceImpl final : public KeyValueStore::Service {
+    Status GetValues(ServerContext *, ServerReaderWriter<Response, Request> *stream) override {
+        Request request;
+        while (stream->Read(&request)) {
+            Response response;
+            response.set_value(get_value_from_map(request.key().c_str()));
+            stream->Write(response);
+        }
+        return Status::OK;
+    }
+};
+
+void RunServer() {
+    std::string              server_address("0.0.0.0:50051");
+    KeyValueStoreServiceImpl service;
+
+    ServerBuilder builder;
+    // Listen on the given address without any authentication mechanism.
+    builder.AddListeningPort(server_address, grpc::InsecureServerCredentials());
+    // Register "service" as the instance through which we'll communicate with
+    // clients. In this case, it corresponds to an *synchronous* service.
+    builder.RegisterService(&service);
+    // Finally assemble the server.
+    std::unique_ptr<Server> server(builder.BuildAndStart());
+    std::cout << "Server listening on " << server_address << std::endl;
+
+    // Wait for the server to shutdown. Note that some other thread must be
+    // responsible for shutting down the server for this call to ever return.
+    server->Wait();
+}
+
+int main() {
+    RunServer();
+    return EXIT_SUCCESS;
+}

--- a/server/keyvalue-server.cpp
+++ b/server/keyvalue-server.cpp
@@ -19,9 +19,9 @@
 
 #include <cstdlib>
 #include <iostream>
+#include <map>
 #include <memory>
 #include <string>
-#include <vector>
 
 #include "grpcpp/grpcpp.h"
 
@@ -36,53 +36,36 @@ using keyvaluestore::KeyValueStore;
 using keyvaluestore::Request;
 using keyvaluestore::Response;
 
-struct kv_pair {
-    const char *key = nullptr;
-    const char *value = nullptr;
-};
-
-static const kv_pair kvs_map[] = {
-    {"key1", "value1"}, {"key2", "value2"}, {"key3", "value3"}, {"key4", "value4"}, {"key5", "value5"},
-};
-
-const char *get_value_from_map(const char *key) {
-    for (size_t i = 0; i < sizeof(kvs_map) / sizeof(kv_pair); ++i) {
-        if (strcmp(key, kvs_map[i].key) == 0) {
-            return kvs_map[i].value;
-        }
-    }
-    return "";
-}
-
 // Logic and data behind the server's behavior.
 class KeyValueStoreServiceImpl final : public KeyValueStore::Service {
     Status GetValues(ServerContext *, ServerReaderWriter<Response, Request> *stream) override {
-        Request request;
+        Request  request;
+        Response response;
         while (stream->Read(&request)) {
-            Response response;
-            response.set_value(get_value_from_map(request.key().c_str()));
+            response.Clear();
+            auto const it = db.find(request.key());
+            response.set_value(it != db.cend() ? it->second : empty_value);
+            std::cout << request.key() << ": " << response.value() << "\n";
             stream->Write(response);
         }
         return Status::OK;
     }
+
+  private:
+    const std::map<std::string, std::string> db = {
+        {"key1", "value1"}, {"key2", "value2"}, {"key3", "value3"}, {"key4", "value4"}, {"key5", "value5"}};
+    const std::string empty_value = "";
 };
 
-void RunServer() {
-    std::string              server_address("0.0.0.0:50051");
+void RunServer(const std::string server_address = "0.0.0.0:50051") {
     KeyValueStoreServiceImpl service;
 
     ServerBuilder builder;
-    // Listen on the given address without any authentication mechanism.
     builder.AddListeningPort(server_address, grpc::InsecureServerCredentials());
-    // Register "service" as the instance through which we'll communicate with
-    // clients. In this case, it corresponds to an *synchronous* service.
     builder.RegisterService(&service);
-    // Finally assemble the server.
+
     std::unique_ptr<Server> server(builder.BuildAndStart());
     std::cout << "Server listening on " << server_address << std::endl;
-
-    // Wait for the server to shutdown. Note that some other thread must be
-    // responsible for shutting down the server for this call to ever return.
     server->Wait();
 }
 


### PR DESCRIPTION
Below are changes:
1. Add the grpc's key-value example
2. Modernize the client and server code.
3. Adding spaces to the output strings so the client/server log messages are less confusing.